### PR TITLE
Implement logged-out password reset

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.0'
   gem 'faker'
   gem 'pry-rails'
+  gem 'pry-byebug'
   gem 'factory_girl_rails'
   gem 'database_cleaner'
   gem 'simplecov', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,9 @@ GEM
     arel (5.0.1.20140414130214)
     bcrypt (3.1.7)
     builder (3.2.2)
+    byebug (2.7.0)
+      columnize (~> 0.3)
+      debugger-linecache (~> 1.2)
     capistrano (2.15.5)
       highline
       net-scp (>= 1.0.0)
@@ -43,7 +46,9 @@ GEM
     capistrano-rails (1.0.0)
       capistrano
     coderay (1.1.0)
+    columnize (0.9.0)
     database_cleaner (1.3.0)
+    debugger-linecache (1.2.0)
     devise (3.2.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -96,6 +101,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (1.3.3)
+      byebug (~> 2.7)
+      pry (~> 0.10)
     pry-rails (0.3.2)
       pry (>= 0.9.10)
     puma (2.11.1)
@@ -188,6 +196,7 @@ DEPENDENCIES
   foreigner
   money-rails
   pg
+  pry-byebug
   pry-rails
   puma
   pundit

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', root_url(reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,10 @@ module CobudgetApi
                  :max_age => 0
       end
     end
+
+    config.to_prepare do
+      Devise::PasswordsController.skip_before_filter :authenticate_from_token!,
+                                                     only: [:create, :update]
+    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,6 +34,6 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = { :address => "localhost", :port => 1025 }
-  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  config.action_mailer.default_url_options = { host: 'localhost:9000' }
   config.action_mailer.raise_delivery_errors = true
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -10,7 +10,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'Cobudget <noreply@cobudget.co>'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
 
-  devise_for :users
+  devise_for :users, defaults: {format: :json}, path_names: {
+    password: 'reset_password'
+  }
   apipie
   resources :auth, only: [], defaults: { format: :json } do
     collection do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,5 +1,0 @@
-require "rails_helper"
-
-RSpec.describe UserMailer, :type => :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -7,7 +7,7 @@ describe "Users" do
   context 'resetting password when logged out' do
     let(:request_headers) { logged_out_headers }
 
-    describe "POST /users/password/reset" do
+    describe "POST /users/reset_password" do
       let(:user) { FactoryGirl.create(:user) }
       let(:user_params) {
         { user:
@@ -16,7 +16,7 @@ describe "Users" do
       }
 
       it 'sends password reset email' do
-        post "/users/password", user_params, request_headers
+        post "/users/reset_password", user_params, request_headers
 
         email = ActionMailer::Base.deliveries.last
         expect(response.status).to eq created
@@ -25,7 +25,7 @@ describe "Users" do
       end
     end
 
-    describe "PUT /users/password" do
+    describe "PUT /users/reset_password" do
       let(:user) { FactoryGirl.create(:user) }
       let(:token) { user.send_reset_password_instructions }
       let(:user_params) { {user: reset_password_params}.to_json }
@@ -38,7 +38,7 @@ describe "Users" do
 
       context 'correct reset token' do
         it 'resets password' do
-          put "/users/password", user_params, request_headers
+          put "/users/reset_password", user_params, request_headers
           user.reload
           expect(response.status).to eq updated
           expect(user.valid_password?('johnkeyisgreat')).to eq(true)

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -4,6 +4,49 @@ describe "Users" do
   let(:user) { FactoryGirl.create(:user) }
   let(:another_user) { FactoryGirl.create(:user) }
 
+  context 'resetting password when logged out' do
+    let(:request_headers) { logged_out_headers }
+
+    describe "POST /users/password/reset" do
+      let(:user) { FactoryGirl.create(:user) }
+      let(:user_params) {
+        { user:
+          { email: user.email }
+        }.to_json
+      }
+
+      it 'sends password reset email' do
+        post "/users/password", user_params, request_headers
+
+        email = ActionMailer::Base.deliveries.last
+        expect(response.status).to eq created
+        expect(email.to[0]).to match(user.email)
+        expect(email.subject).to match('password')
+      end
+    end
+
+    describe "PUT /users/password" do
+      let(:user) { FactoryGirl.create(:user) }
+      let(:token) { user.send_reset_password_instructions }
+      let(:user_params) { {user: reset_password_params}.to_json }
+      let(:reset_password_params) {
+        { reset_password_token: token,
+          password: 'johnkeyisgreat',
+          password_confirmation: 'johnkeyisgreat'
+        }
+      }
+
+      context 'correct reset token' do
+        it 'resets password' do
+          put "/users/password", user_params, request_headers
+          user.reload
+          expect(response.status).to eq updated
+          expect(user.valid_password?('johnkeyisgreat')).to eq(true)
+        end
+      end
+    end
+  end
+
   describe "PUT /users/:user_id" do
     let(:user) { FactoryGirl.create(:user) }
     let(:user_params) {

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -23,11 +23,15 @@ module MyLetDeclarations
   let(:forbidden) { 403 }
   let(:unprocessable) { 422 }
 
-  let(:request_headers) { {
+  let(:request_headers) { logged_in_headers }
+  let(:logged_out_headers) {{
     "Accept" => "application/json",
-    "Content-Type" => "application/json",
+    "Content-Type" => "application/json"
+  }}
+  let(:logged_in_headers) {{
     "X-User-Token" => user.access_token,
-    "X-User-Email" => user.email,
-  } }
+    "X-User-Email" => user.email
+  }.merge(logged_out_headers)}
+
 end
 RSpec.configure { |c| c.include MyLetDeclarations }

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -23,6 +23,7 @@ module MyLetDeclarations
   let(:forbidden) { 403 }
   let(:unprocessable) { 422 }
 
+  # Request headers
   let(:request_headers) { logged_in_headers }
   let(:logged_out_headers) {{
     "Accept" => "application/json",


### PR DESCRIPTION
@ahdinosaur I've implemented a basic version of password reset using Devise's built-in commands.

Here's how it works from an API perspective:

**POST /users/reset_password**
- Takes: {user: {email: 'whatever@example.com'}}
- Sends an email to the specified address containing a link to reset their password
  - The link looks like: http://app.cobudget.co/users/password/edit?reset_password_token=dASU-JxBvLnQJzfSdVxN
- Returns 201 on success

Note: the link above is just the default that devise creates. I know it's probably not ideal from the UI perspective. Let me know if you want me to change it and I can.

**PUT /users/reset_password**
- Takes: {user: {reset_password_token: 'dASU-JxBvLnQJzfSdVxN', password: 'fakepassword', password_confirmation: 'fakepassword}}
- Returns 204 on success

Let me know what you think / if you have questions.

:heart: :heart: :heart: 